### PR TITLE
Add bash upgrade instructions for mac users

### DIFF
--- a/src/content/docs/guides/advanced.mdx
+++ b/src/content/docs/guides/advanced.mdx
@@ -5,6 +5,30 @@ description: Advanced configurations and options
 
 import { Steps } from '@astrojs/starlight/components';
 
+## **Using the `.bidsignore` file to filter a BIDS dataset**
+
+**When should I use a `.bidsignore` file?**
+
+**When you want to hide specific files from `sf-pediatric`'s BIDS reader.** In case your dataset contains files that could
+be matched by the pipeline but that you do not want to process, you can specify specific patterns to exclude using a root-level
+`.bidsignore` file (this means at the same level as the `participants.tsv` file). This file should only contain regex patterns that should be excluded. Here's an example if you want to
+exclude the DWI run-02 from a specific subject (e.g., sub-01):
+
+```txt title=".bidsignore"
+# Excluding run-02 from subject sub-01 across all possible sessions
+sub-01/**/*run-02*
+```
+
+You can also use this file to exclude other files matching more global or complex patterns. For example, here's a `.bidsignore`
+file that excludes the localizers and spine DWI acquisitions:
+
+```txt title=".bidsignore"
+# Localizers
+**/anat/*localizer*
+# Spine DWI acquisitions
+*/*/*/*_bp-cspine*
+```
+
 ## **Using a `params.yml` file**
 
 **When should I use a `params.yml` file to supply my parameters?**

--- a/src/content/docs/guides/inputs.mdx
+++ b/src/content/docs/guides/inputs.mdx
@@ -34,6 +34,12 @@ The most basic BIDS directory should have a similar structure (note that session
         - sub-01_ses-01_epi.json
 </FileTree>
 
+:::note[`sf-pediatric` will log missing files at runtime]
+When reading your BIDS dataset, `sf-pediatric` will log information regarding which file it was able to find and which
+ones are missing in a `BIDS_logs.txt` file saved in your [`$params.outdir`](/sf-pediatric/guides/parameters/#inputoutput-options)`/pipeline_info/`. This is the best place to debug
+unexpected BIDS-related behavior when processing your dataset.
+:::
+
 ### **Required Files**
 
 - `dataset_description.json`: A JSON file describing the dataset.
@@ -65,3 +71,11 @@ In order for `sf-pediatric` to properly read the `participants.tsv` file, column
     - `T2w` is **mandatory** for participants < 3 months old (only for the segmentation profile, otherwise a T1w will also work).
   - `dwi/`: A directory containing diffusion-weighted imaging data (e.g., DWI, bval, bvec). Acquisition with both direction DWI data are also supported (e.g. AP/PA). Specify them according to the [BIDS guidelines](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html)
   - `fmap/`: A directory containing field map data (optional but recommended for distortion correction).
+
+:::tip[Handling multiple runs]
+If your dataset contains multiple DWI runs, `sf-pediatric` will consider each of them as a separate DWI acquisition
+and will process them separately. The extracted `run-XX` tags will be carried over to the output folder, so each run will be
+properly identified. **However, if runs exist in the anatomical images, those will not be considered separate**, and the
+last one will be kept for processing. To override this behavior, you can use the `.bidsignore` file. For detailed instructions,
+please refer [to this section](/sf-pediatric/guides/advanced/#using-the-bidsignore-file-to-filter-a-bids-dataset).
+:::

--- a/src/content/docs/guides/installation.mdx
+++ b/src/content/docs/guides/installation.mdx
@@ -10,6 +10,12 @@ import CommandOutputs from '../../../components/CommandOutputs.astro';
 
 While you do not need to install every software used within `sf-pediatric`, there is two core dependencies that need to be available at runtime: 
 
+:::caution[For MacOS Users]
+MacOS users should also upgrade their bash version to at least `4.3`. To do so, you can use Homebrew as [described here](https://apple.stackexchange.com/questions/193411/update-bash-to-version-4-0-on-osx). If you don't have Homebrew installed, you can [follow the instructions on their documentation here](http://brew.sh/). To upgrade to the latest bash version, run this command:
+```bash
+brew install bash
+```
+:::
 
 <Steps>
 


### PR DESCRIPTION
When we will switch to nf-bids, the libBIDS.sh requires bash version >= `4.3`. This adds a warning for MacOS users to ugrade their bash version.

- [x] Add details on how to use `.gitignore`.