### PR TITLE
FEAT: Update documentation for running without internet access

### DIFF
--- a/src/content/docs/guides/nointernet.mdx
+++ b/src/content/docs/guides/nointernet.mdx
@@ -41,7 +41,7 @@ Some computing nodes do not have access to the internet at runtime. Since the pi
     <Tabs>
     <TabItem label="Command">
     ```bash
-    curl -fsSL https://github.com/nf-neuro/modules/blob/main/assets/download_pipeline.sh | bash -s -- -p scilus/sf-pediatric -r 0.2.1 -d 1 -o ./containers -c ./singularity_cache
+    curl -fsSL https://raw.githubusercontent.com/nf-neuro/modules/main/assets/download_pipeline.sh | bash -s -- -p scilus/sf-pediatric -r 0.2.1 -d 1 -o ./containers -c ./singularity_cache
     ```
     </TabItem>
     <TabItem label="Expected Output">


### PR DESCRIPTION
Following the feedback we got, and the new download script for containers. I've updated the sf-pediatric documentation to include details on launching the pipeline on clusters (using either tmux or a single sbatch job). 

I would like a quick review if possible @AntoineTheb @arnaudbore @AlexVCaron, just to make sure I did not forget anything! 