### PR TITLE
FIX: Hide the hidden column from the parameter page

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -78,7 +78,11 @@
 .sl-markdown-content table th,
 .sl-markdown-content table td:first-child,
 .sl-markdown-content table td:nth-child(3),
-.sl-markdown-content table td:nth-child(5),
+.sl-markdown-content table td:nth-child(5) {
+	white-space: nowrap;
+}
+
+.sl-markdown-content table th:nth-child(6),
 .sl-markdown-content table td:nth-child(6) {
-  white-space: nowrap;
+	display: none;
 }


### PR DESCRIPTION
For some reason, the hidden column was still showing on the parameters page. This PR hides it.